### PR TITLE
avoid relative import

### DIFF
--- a/tests/test_balanced.py
+++ b/tests/test_balanced.py
@@ -1,7 +1,7 @@
 import interleaving as il
 import numpy as np
 np.random.seed(0)
-from .test_methods import TestMethods
+from test_methods import TestMethods
 
 class TestBalanced(TestMethods):
 

--- a/tests/test_team_draft.py
+++ b/tests/test_team_draft.py
@@ -1,7 +1,7 @@
 import interleaving as il
 import numpy as np
 np.random.seed(0)
-from .test_methods import TestMethods
+from test_methods import TestMethods
 
 class TestTeamDraft(TestMethods):
 


### PR DESCRIPTION
Closes #3 .

It works because `import` searches the directory of the input script.
